### PR TITLE
Begin sync refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ lettre = { version = "0.11.6", features = [
 ] }
 reqwest = { version = "0.11", features = ["json"] }
 notify = "6.1.1"
+automerge = "0.5"
+rusqlite = { version = "0.31.0", features = ["bundled"] }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/crates/lst-cli/src/config.rs
+++ b/crates/lst-cli/src/config.rs
@@ -61,6 +61,12 @@ pub struct SyncdConfig {
     
     /// Device identifier (auto-generated if missing)
     pub device_id: Option<String>,
+
+    /// Path to the local sync database
+    pub database_path: Option<PathBuf>,
+
+    /// Reference to the encryption key
+    pub encryption_key_ref: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -243,10 +249,18 @@ impl Config {
                 .join("lst")
                 .join("crdt");
             
+            let config_dir = dirs::config_dir()
+                .context("Cannot determine config directory")?
+                .join("lst");
+
+            let db_path = config_dir.join("syncd.db");
+
             self.syncd = Some(SyncdConfig {
                 url: None,
                 auth_token: None,
                 device_id: Some(uuid::Uuid::new_v4().to_string()),
+                database_path: Some(db_path),
+                encryption_key_ref: Some("lst-master-key".to_string()),
             });
             
             self.storage = Some(StorageConfig {

--- a/crates/lst-proto/src/lib.rs
+++ b/crates/lst-proto/src/lib.rs
@@ -2,60 +2,29 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use chrono::{DateTime, Utc};
 
+/// Information about a document stored on the server
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SyncMessage {
-    pub id: Uuid,
-    pub timestamp: DateTime<Utc>,
-    pub payload: SyncPayload,
+pub struct DocumentInfo {
+    pub doc_id: Uuid,
+    pub updated_at: DateTime<Utc>,
 }
 
+/// Messages sent from the client to the server
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum SyncPayload {
-    ListUpdate(ListUpdate),
-    NoteUpdate(NoteUpdate),
-    PostUpdate(PostUpdate),
+pub enum ClientMessage {
+    Authenticate { jwt: String },
+    RequestDocumentList,
+    RequestSnapshot { doc_id: Uuid },
+    PushChanges { doc_id: Uuid, device_id: String, changes: Vec<Vec<u8>> },
+    PushSnapshot { doc_id: Uuid, snapshot: Vec<u8> },
 }
 
+/// Messages sent from the server to the client
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ListUpdate {
-    pub list_name: String,
-    pub operation: ListOperation,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum ListOperation {
-    Add { item: String },
-    Remove { item_id: Uuid },
-    Complete { item_id: Uuid },
-    Uncomplete { item_id: Uuid },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NoteUpdate {
-    pub note_id: String,
-    pub content: String,
-    pub operation: NoteOperation,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum NoteOperation {
-    Create,
-    Update,
-    Delete,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PostUpdate {
-    pub post_id: String,
-    pub content: String,
-    pub operation: PostOperation,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum PostOperation {
-    Create,
-    Update,
-    Delete,
-    Publish,
-    Unpublish,
+pub enum ServerMessage {
+    Authenticated { success: bool },
+    DocumentList { documents: Vec<DocumentInfo> },
+    Snapshot { doc_id: Uuid, snapshot: Vec<u8> },
+    NewChanges { doc_id: Uuid, from_device_id: String, changes: Vec<Vec<u8>> },
+    RequestCompaction { doc_id: Uuid },
 }

--- a/crates/lst-syncd/Cargo.toml
+++ b/crates/lst-syncd/Cargo.toml
@@ -34,6 +34,8 @@ chrono = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 dirs = { workspace = true }
+automerge = { workspace = true }
+rusqlite = { workspace = true }
 
 # HTTP client
 reqwest = { workspace = true }

--- a/crates/lst-syncd/src/config.rs
+++ b/crates/lst-syncd/src/config.rs
@@ -32,18 +32,30 @@ pub fn load_syncd_config(path: &Path) -> Result<Config> {
             println!("Added sync daemon settings to existing config");
         }
         
-        // Generate device_id if missing
+        // Ensure required syncd fields are present
         if let Some(syncd) = &config.syncd {
-            if syncd.device_id.is_none() {
+            if syncd.device_id.is_none() || syncd.database_path.is_none() || syncd.encryption_key_ref.is_none() {
                 let mut updated_config = config.clone();
-                if let Some(ref mut syncd) = updated_config.syncd {
-                    let device_id = uuid::Uuid::new_v4().to_string();
-                    syncd.device_id = Some(device_id.clone());
-                    updated_config.save()
-                        .context("Failed to save config with new device_id")?;
-                    println!("Generated new device_id: {}", device_id);
-                    return Ok(updated_config);
+                if let Some(ref mut syncd_cfg) = updated_config.syncd {
+                    if syncd_cfg.device_id.is_none() {
+                        let device_id = uuid::Uuid::new_v4().to_string();
+                        syncd_cfg.device_id = Some(device_id.clone());
+                        println!("Generated new device_id: {}", device_id);
+                    }
+                    if syncd_cfg.database_path.is_none() {
+                        let db_path = dirs::config_dir()
+                            .context("Cannot determine config directory")?
+                            .join("lst")
+                            .join("syncd.db");
+                        syncd_cfg.database_path = Some(db_path);
+                    }
+                    if syncd_cfg.encryption_key_ref.is_none() {
+                        syncd_cfg.encryption_key_ref = Some("lst-master-key".to_string());
+                    }
                 }
+                updated_config.save()
+                    .context("Failed to save updated syncd config")?;
+                return Ok(updated_config);
             }
         }
         

--- a/crates/lst-syncd/src/database.rs
+++ b/crates/lst-syncd/src/database.rs
@@ -1,0 +1,46 @@
+use anyhow::{Context, Result};
+use rusqlite::{Connection, params};
+use std::path::Path;
+
+/// Local SQLite database used by lst-syncd
+pub struct LocalDb {
+    conn: Connection,
+}
+
+impl LocalDb {
+    /// Open the database at the given path and initialize tables if needed
+    pub fn new(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("Failed to create db directory: {}", parent.display()))?;
+        }
+        let conn = Connection::open(path)
+            .with_context(|| format!("Failed to open database: {}", path.display()))?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS documents (
+                doc_id TEXT PRIMARY KEY,
+                file_path TEXT NOT NULL UNIQUE,
+                doc_type TEXT NOT NULL,
+                last_sync_hash TEXT,
+                automerge_state BLOB NOT NULL
+            );",
+        )?
+        ;
+        Ok(Self { conn })
+    }
+
+    /// Insert or update a document row
+    pub fn upsert_document(&self, doc_id: &str, file_path: &str, doc_type: &str, last_sync_hash: &str, state: &[u8]) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO documents (doc_id, file_path, doc_type, last_sync_hash, automerge_state)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(doc_id) DO UPDATE SET
+                file_path = excluded.file_path,
+                doc_type = excluded.doc_type,
+                last_sync_hash = excluded.last_sync_hash,
+                automerge_state = excluded.automerge_state",
+            params![doc_id, file_path, doc_type, last_sync_hash, state],
+        )?;
+        Ok(())
+    }
+}

--- a/crates/lst-syncd/src/main.rs
+++ b/crates/lst-syncd/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod sync;
 mod watcher;
+mod database;
 
 use anyhow::Result;
 use clap::Parser;


### PR DESCRIPTION
## Summary
- start building sync engine foundations
- define WebSocket protocol types in `lst-proto`
- extend CLI configuration with database and encryption key settings
- set up local database helper in sync daemon
- integrate new database and config fields into sync daemon
- add automerge and rusqlite dependencies

## Testing
- `cargo fmt --all` *(fails: rustfmt not installed)*
- `rustup component add rustfmt` *(fails: network error)*
- `cargo build` *(fails: failed to get dependencies)*
- `cargo clippy -- -D warnings` *(fails: clippy not installed)*
- `rustup component add clippy` *(fails: network error)*
- `cargo test` *(fails: failed to get dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68453d8884488321b648cf93b28e7288