### PR TITLE
Implement Automerge update logic

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,18 +12,18 @@
 - [ ] **lst-syncd (Client-side Sync Daemon):**
   - [x] Scaffold `lst-syncd` daemon with file watching
   - [ ] **Integrate `automerge` crate for CRDT-based list and note synchronization:**
-    - [ ] Add `automerge` (with `rusqlite` feature), `rusqlite` (for `syncd.db`), and `uuid` dependencies to `lst-syncd/Cargo.toml`.
-    - [ ] **Implement `syncd.db` (SQLite) for local Automerge state management (`lst-syncd/src/database.rs` or similar):**
-      - [ ] Define `documents` table schema: `doc_id` (UUID PK), `file_path` (TEXT UNIQUE), `doc_type` (TEXT, e.g., 'list', 'note'), `last_sync_hash` (TEXT), `automerge_state` (BLOB for the full Automerge document).
-      - [ ] Implement function to initialize the database and table.
-    - [ ] **Develop logic for processing local file changes into Automerge documents (`lst-syncd/src/sync.rs` or similar):**
-      - [ ] On file change, read content and compare its hash with `last_sync_hash` from `syncd.db`.
-      - [ ] If different, load `automerge_state` for the file. If no state, create a new `Automerge` document.
+    - [x] Add `automerge` (with `rusqlite` feature), `rusqlite` (for `syncd.db`), and `uuid` dependencies to `lst-syncd/Cargo.toml`.
+    - [x] **Implement `syncd.db` (SQLite) for local Automerge state management (`lst-syncd/src/database.rs` or similar):**
+      - [x] Define `documents` table schema: `doc_id` (UUID PK), `file_path` (TEXT UNIQUE), `doc_type` (TEXT, e.g., 'list', 'note'), `last_sync_hash` (TEXT), `automerge_state` (BLOB for the full Automerge document), `owner` (TEXT), `writers` (TEXT), `readers` (TEXT).
+      - [x] Implement function to initialize the database and table.
+    - [x] **Develop logic for processing local file changes into Automerge documents (`lst-syncd/src/sync.rs` or similar):**
+      - [x] On file change, read content and compare its hash with `last_sync_hash` from `syncd.db`.
+      - [x] If different, load `automerge_state` for the file. If no state, create a new `Automerge` document.
       - [ ] Generate Automerge changes:
         - For lists: Apply line-by-line diffs to the Automerge document (or structured diff based on itemization).
-        - For notes: Use `tx.update_text()` on a root "content" field in an Automerge transaction.
-      - [ ] Save the updated full `automerge_state` back to `syncd.db` and update `last_sync_hash`.
-      - [ ] Extract compact Automerge changes/diffs (`Vec<u8>`) using `doc.get_changes_added()` for network transmission.
+        - [x] For notes: Use `tx.update_text()` on a root "content" field in an Automerge transaction.
+      - [x] Save the updated full `automerge_state` back to `syncd.db` and update `last_sync_hash`.
+      - [x] Extract compact Automerge changes/diffs (`Vec<u8>`) using `doc.get_changes_added()` for network transmission.
     - [ ] **Develop logic for applying remote Automerge changes to local files:**
       - [ ] After receiving an encrypted Automerge change set from `lst-server` and decrypting it:
       - [ ] Load the corresponding `automerge_state` from `syncd.db`.

--- a/crates/lst-syncd/Cargo.toml
+++ b/crates/lst-syncd/Cargo.toml
@@ -34,7 +34,7 @@ chrono = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 dirs = { workspace = true }
-automerge = { workspace = true }
+automerge = { workspace = true, features = ["rusqlite"] }
 rusqlite = { workspace = true }
 sha2 = { workspace = true }
 

--- a/crates/lst-syncd/src/database.rs
+++ b/crates/lst-syncd/src/database.rs
@@ -25,7 +25,7 @@ impl LocalDb {
                 automerge_state BLOB NOT NULL,
                 owner TEXT NOT NULL,
                 writers TEXT,
-                readers TEXT,
+                readers TEXT
             );",
         )?;
         Ok(Self { conn })
@@ -39,10 +39,13 @@ impl LocalDb {
         doc_type: &str,
         last_sync_hash: &str,
         state: &[u8],
+        owner: &str,
+        writers: Option<&str>,
+        readers: Option<&str>,
     ) -> Result<()> {
         self.conn.execute(
-            "INSERT INTO documents (doc_id, file_path, doc_type, last_sync_hash, automerge_state)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            "INSERT INTO documents (doc_id, file_path, doc_type, last_sync_hash, automerge_state, owner, writers, readers)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
              ON CONFLICT(doc_id) DO UPDATE SET
                 file_path = excluded.file_path,
                 doc_type = excluded.doc_type,
@@ -51,15 +54,53 @@ impl LocalDb {
                 owner = excluded.owner,
                 writers = excluded.writers,
                 readers = excluded.readers",
-            params![doc_id, file_path, doc_type, last_sync_hash, state],
+            params![doc_id, file_path, doc_type, last_sync_hash, state, owner, writers, readers],
         )?;
         Ok(())
+    }
+
+    /// Fetch a document row by doc_id
+    pub fn get_document(
+        &self,
+        doc_id: &str,
+    ) -> Result<Option<(String, String, String, Vec<u8>, String, Option<String>, Option<String>)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT file_path, doc_type, last_sync_hash, automerge_state, owner, writers, readers FROM documents WHERE doc_id = ?1",
+        )?;
+        let mut rows = stmt.query(params![doc_id])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+                row.get(6)?,
+            )))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Delete a document by id
     pub fn delete_document(&self, doc_id: &str) -> Result<()> {
         self.conn
             .execute("DELETE FROM documents WHERE doc_id = ?1", params![doc_id])?;
+        Ok(())
+    }
+
+    /// Update writers and readers for a document
+    pub fn update_shares(
+        &self,
+        doc_id: &str,
+        writers: Option<&str>,
+        readers: Option<&str>,
+    ) -> Result<()> {
+        self.conn.execute(
+            "UPDATE documents SET writers = ?2, readers = ?3 WHERE doc_id = ?1",
+            params![doc_id, writers, readers],
+        )?;
         Ok(())
     }
 }

--- a/crates/lst-syncd/src/sync.rs
+++ b/crates/lst-syncd/src/sync.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::database::LocalDb;
 use anyhow::{Context, Result};
-use automerge::{Automerge, Change, ReadDoc, Transactable};
+use automerge::{transaction::Transactable as _, Automerge, Change, ReadDoc};
 use notify::Event;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -94,13 +94,86 @@ impl SyncManager {
                 .and_then(|e| e.to_str())
                 .unwrap_or("unknown");
 
-            self.db
-                .upsert_document(&doc_id, &path.to_string_lossy(), doc_type, &hash, &data)?;
+            let owner = self
+                .config
+                .syncd
+                .as_ref()
+                .and_then(|s| s.device_id.as_ref())
+                .map(String::as_str)
+                .unwrap_or("local");
 
-            self.pending_changes
-                .entry(doc_id)
-                .or_insert_with(Vec::new)
-                .push(data);
+            let new_content = String::from_utf8_lossy(&data);
+
+            if let Some((_, _, last_hash, state, existing_owner, writers, readers)) =
+                self.db.get_document(&doc_id)?
+            {
+                if last_hash == hash {
+                    continue;
+                }
+
+                let mut doc = Automerge::load(&state)?;
+                let old_heads = doc.get_heads();
+
+                let mut tx = doc.transaction();
+                tx.put(automerge::ROOT, "content", "").ok();
+                tx.update_text(automerge::ROOT, "content", &new_content)?;
+                tx.commit();
+
+                let new_state = doc.save();
+
+                self.db.upsert_document(
+                    &doc_id,
+                    &path.to_string_lossy(),
+                    doc_type,
+                    &hash,
+                    &new_state,
+                    &existing_owner,
+                    writers.as_deref(),
+                    readers.as_deref(),
+                )?;
+
+                let changes = doc
+                    .get_changes_added(&old_heads)
+                    .into_iter()
+                    .map(|c| c.raw_bytes().to_vec())
+                    .collect::<Vec<_>>();
+
+                self.pending_changes
+                    .entry(doc_id)
+                    .or_insert_with(Vec::new)
+                    .extend(changes);
+            } else {
+                let mut doc = Automerge::new();
+                let old_heads = doc.get_heads();
+                let mut tx = doc.transaction();
+                tx.put(automerge::ROOT, "content", "").ok();
+                tx.update_text(automerge::ROOT, "content", &new_content)?;
+                tx.commit();
+
+                let new_state = doc.save();
+
+                self.db.upsert_document(
+                    &doc_id,
+                    &path.to_string_lossy(),
+                    doc_type,
+                    &hash,
+                    &new_state,
+                    owner,
+                    None,
+                    None,
+                )?;
+
+                let changes = doc
+                    .get_changes_added(&old_heads)
+                    .into_iter()
+                    .map(|c| c.raw_bytes().to_vec())
+                    .collect::<Vec<_>>();
+
+                self.pending_changes
+                    .entry(doc_id)
+                    .or_insert_with(Vec::new)
+                    .extend(changes);
+            }
         }
 
         Ok(())


### PR DESCRIPTION
## Summary
- mark local Automerge processing tasks in TODO
- update SyncManager to load or create Automerge docs
- store new state and queue changes for sync

## Testing
- `cargo fmt --all` *(failed: rustfmt not installed)*
- `cargo check -p lst-syncd` *(failed to download from crates.io)*
- `cargo check -p lst-syncd --locked` *(failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_b_6846b7f01a00832199ff15500341490e