### PR TITLE
Implement list diff logic

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,25 +12,25 @@
 - [ ] **lst-syncd (Client-side Sync Daemon):**
   - [x] Scaffold `lst-syncd` daemon with file watching
   - [ ] **Integrate `automerge` crate for CRDT-based list and note synchronization:**
-    - [ ] Add `automerge` (with `rusqlite` feature), `rusqlite` (for `syncd.db`), and `uuid` dependencies to `lst-syncd/Cargo.toml`.
-    - [ ] **Implement `syncd.db` (SQLite) for local Automerge state management (`lst-syncd/src/database.rs` or similar):**
-      - [ ] Define `documents` table schema: `doc_id` (UUID PK), `file_path` (TEXT UNIQUE), `doc_type` (TEXT, e.g., 'list', 'note'), `last_sync_hash` (TEXT), `automerge_state` (BLOB for the full Automerge document).
-      - [ ] Implement function to initialize the database and table.
-    - [ ] **Develop logic for processing local file changes into Automerge documents (`lst-syncd/src/sync.rs` or similar):**
-      - [ ] On file change, read content and compare its hash with `last_sync_hash` from `syncd.db`.
-      - [ ] If different, load `automerge_state` for the file. If no state, create a new `Automerge` document.
-      - [ ] Generate Automerge changes:
+    - [x] Add `automerge` (with `rusqlite` feature), `rusqlite` (for `syncd.db`), and `uuid` dependencies to `lst-syncd/Cargo.toml`.
+    - [x] **Implement `syncd.db` (SQLite) for local Automerge state management (`lst-syncd/src/database.rs` or similar):**
+      - [x] Define `documents` table schema: `doc_id` (UUID PK), `file_path` (TEXT UNIQUE), `doc_type` (TEXT, e.g., 'list', 'note'), `last_sync_hash` (TEXT), `automerge_state` (BLOB for the full Automerge document), `owner` (TEXT), `writers` (TEXT), `readers` (TEXT).
+      - [x] Implement function to initialize the database and table.
+    - [x] **Develop logic for processing local file changes into Automerge documents (`lst-syncd/src/sync.rs` or similar):**
+      - [x] On file change, read content and compare its hash with `last_sync_hash` from `syncd.db`.
+      - [x] If different, load `automerge_state` for the file. If no state, create a new `Automerge` document.
+      - [x] Generate Automerge changes:
         - For lists: Apply line-by-line diffs to the Automerge document (or structured diff based on itemization).
-        - For notes: Use `tx.update_text()` on a root "content" field in an Automerge transaction.
-      - [ ] Save the updated full `automerge_state` back to `syncd.db` and update `last_sync_hash`.
-      - [ ] Extract compact Automerge changes/diffs (`Vec<u8>`) using `doc.get_changes_added()` for network transmission.
-    - [ ] **Develop logic for applying remote Automerge changes to local files:**
-      - [ ] After receiving an encrypted Automerge change set from `lst-server` and decrypting it:
-      - [ ] Load the corresponding `automerge_state` from `syncd.db`.
-      - [ ] Apply the decrypted Automerge changes to the document (`doc.apply_changes()`).
-      - [ ] Re-render the full Automerge document back into Markdown format (preserving frontmatter if possible).
-      - [ ] Overwrite the local Markdown file with the new content.
-      - [ ] Save the updated `automerge_state` to `syncd.db` and update `last_sync_hash`.
+        - [x] For notes: Use `tx.update_text()` on a root "content" field in an Automerge transaction.
+      - [x] Save the updated full `automerge_state` back to `syncd.db` and update `last_sync_hash`.
+      - [x] Extract compact Automerge changes/diffs (`Vec<u8>`) using `doc.get_changes_added()` for network transmission.
+    - [x] **Develop logic for applying remote Automerge changes to local files:**
+      - [x] After receiving an encrypted Automerge change set from `lst-server` and decrypting it:
+      - [x] Load the corresponding `automerge_state` from `syncd.db`.
+      - [x] Apply the decrypted Automerge changes to the document (`doc.apply_changes()`).
+      - [x] Re-render the full Automerge document back into Markdown format (preserving frontmatter if possible).
+      - [x] Overwrite the local Markdown file with the new content.
+      - [x] Save the updated `automerge_state` to `syncd.db` and update `last_sync_hash`.
   - [ ] **Implement client-side encryption (XChaCha20-Poly1305) for Automerge data sent to `lst-server`:**
     - [ ] Encrypt generated Automerge change sets (`Vec<u8>`) before sending via WebSocket.
     - [ ] Decrypt received Automerge change sets after receiving via WebSocket.

--- a/crates/lst-syncd/Cargo.toml
+++ b/crates/lst-syncd/Cargo.toml
@@ -34,7 +34,7 @@ chrono = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 dirs = { workspace = true }
-automerge = { workspace = true }
+automerge = { workspace = true, features = ["rusqlite"] }
 rusqlite = { workspace = true }
 sha2 = { workspace = true }
 

--- a/crates/lst-syncd/src/database.rs
+++ b/crates/lst-syncd/src/database.rs
@@ -25,7 +25,7 @@ impl LocalDb {
                 automerge_state BLOB NOT NULL,
                 owner TEXT NOT NULL,
                 writers TEXT,
-                readers TEXT,
+                readers TEXT
             );",
         )?;
         Ok(Self { conn })
@@ -39,10 +39,13 @@ impl LocalDb {
         doc_type: &str,
         last_sync_hash: &str,
         state: &[u8],
+        owner: &str,
+        writers: Option<&str>,
+        readers: Option<&str>,
     ) -> Result<()> {
         self.conn.execute(
-            "INSERT INTO documents (doc_id, file_path, doc_type, last_sync_hash, automerge_state)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            "INSERT INTO documents (doc_id, file_path, doc_type, last_sync_hash, automerge_state, owner, writers, readers)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
              ON CONFLICT(doc_id) DO UPDATE SET
                 file_path = excluded.file_path,
                 doc_type = excluded.doc_type,
@@ -51,15 +54,53 @@ impl LocalDb {
                 owner = excluded.owner,
                 writers = excluded.writers,
                 readers = excluded.readers",
-            params![doc_id, file_path, doc_type, last_sync_hash, state],
+            params![doc_id, file_path, doc_type, last_sync_hash, state, owner, writers, readers],
         )?;
         Ok(())
+    }
+
+    /// Fetch a document row by doc_id
+    pub fn get_document(
+        &self,
+        doc_id: &str,
+    ) -> Result<Option<(String, String, String, Vec<u8>, String, Option<String>, Option<String>)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT file_path, doc_type, last_sync_hash, automerge_state, owner, writers, readers FROM documents WHERE doc_id = ?1",
+        )?;
+        let mut rows = stmt.query(params![doc_id])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some((
+                row.get(0)?,
+                row.get(1)?,
+                row.get(2)?,
+                row.get(3)?,
+                row.get(4)?,
+                row.get(5)?,
+                row.get(6)?,
+            )))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Delete a document by id
     pub fn delete_document(&self, doc_id: &str) -> Result<()> {
         self.conn
             .execute("DELETE FROM documents WHERE doc_id = ?1", params![doc_id])?;
+        Ok(())
+    }
+
+    /// Update writers and readers for a document
+    pub fn update_shares(
+        &self,
+        doc_id: &str,
+        writers: Option<&str>,
+        readers: Option<&str>,
+    ) -> Result<()> {
+        self.conn.execute(
+            "UPDATE documents SET writers = ?2, readers = ?3 WHERE doc_id = ?1",
+            params![doc_id, writers, readers],
+        )?;
         Ok(())
     }
 }

--- a/crates/lst-syncd/src/sync.rs
+++ b/crates/lst-syncd/src/sync.rs
@@ -1,11 +1,54 @@
 use crate::config::Config;
 use crate::database::LocalDb;
 use anyhow::{Context, Result};
-use automerge::{Automerge, Change, ReadDoc, Transactable};
+use automerge::{
+    transaction::Transactable as _,
+    Automerge, Change, ObjType, ReadDoc, ScalarValue, Value,
+};
 use notify::Event;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use tokio::time::Instant;
+
+fn detect_doc_type(path: &std::path::Path) -> &str {
+    let s = path.to_string_lossy();
+    if s.contains("/lists/") || s.contains("daily_lists") {
+        "list"
+    } else {
+        "note"
+    }
+}
+
+fn update_note_doc(doc: &mut Automerge, content: &str) -> Result<()> {
+    let mut tx = doc.transaction();
+    tx.put(automerge::ROOT, "content", "").ok();
+    tx.update_text(automerge::ROOT, "content", content)?;
+    tx.commit();
+    Ok(())
+}
+
+fn update_list_doc(doc: &mut Automerge, content: &str) -> Result<()> {
+    let mut tx = doc.transaction();
+    let items = match doc.get(automerge::ROOT, "items")? {
+        Some((id, _)) => id,
+        None => tx.put_object(automerge::ROOT, "items", ObjType::List)?,
+    };
+
+    let len = doc.length(items);
+    for idx in (0..len).rev() {
+        tx.delete(items, idx)?;
+    }
+
+    for (idx, line) in content.lines().enumerate() {
+        let line = line.trim();
+        if !line.is_empty() {
+            tx.insert(items, idx, ScalarValue::Str(line.into()))?;
+        }
+    }
+
+    tx.commit();
+    Ok(())
+}
 
 pub struct SyncManager {
     config: Config,
@@ -89,18 +132,160 @@ impl SyncManager {
             hasher.update(&data);
             let hash = hex::encode(hasher.finalize());
 
-            let doc_type = path
-                .extension()
-                .and_then(|e| e.to_str())
-                .unwrap_or("unknown");
+            let doc_type = detect_doc_type(&path);
 
-            self.db
-                .upsert_document(&doc_id, &path.to_string_lossy(), doc_type, &hash, &data)?;
+            let owner = self
+                .config
+                .syncd
+                .as_ref()
+                .and_then(|s| s.device_id.as_ref())
+                .map(String::as_str)
+                .unwrap_or("local");
 
-            self.pending_changes
-                .entry(doc_id)
-                .or_insert_with(Vec::new)
-                .push(data);
+            let new_content = String::from_utf8_lossy(&data);
+
+            if let Some((_, _, last_hash, state, existing_owner, writers, readers)) =
+                self.db.get_document(&doc_id)?
+            {
+                if last_hash == hash {
+                    continue;
+                }
+
+                let mut doc = Automerge::load(&state)?;
+                let old_heads = doc.get_heads();
+
+                if doc_type == "list" {
+                    update_list_doc(&mut doc, &new_content)?;
+                } else {
+                    update_note_doc(&mut doc, &new_content)?;
+                }
+
+                let new_state = doc.save();
+
+                self.db.upsert_document(
+                    &doc_id,
+                    &path.to_string_lossy(),
+                    doc_type,
+                    &hash,
+                    &new_state,
+                    &existing_owner,
+                    writers.as_deref(),
+                    readers.as_deref(),
+                )?;
+
+                let changes = doc
+                    .get_changes_added(&old_heads)
+                    .into_iter()
+                    .map(|c| c.raw_bytes().to_vec())
+                    .collect::<Vec<_>>();
+
+                self.pending_changes
+                    .entry(doc_id)
+                    .or_insert_with(Vec::new)
+                    .extend(changes);
+            } else {
+                let mut doc = Automerge::new();
+                let old_heads = doc.get_heads();
+
+                if doc_type == "list" {
+                    update_list_doc(&mut doc, &new_content)?;
+                } else {
+                    update_note_doc(&mut doc, &new_content)?;
+                }
+
+                let new_state = doc.save();
+
+                self.db.upsert_document(
+                    &doc_id,
+                    &path.to_string_lossy(),
+                    doc_type,
+                    &hash,
+                    &new_state,
+                    owner,
+                    None,
+                    None,
+                )?;
+
+                let changes = doc
+                    .get_changes_added(&old_heads)
+                    .into_iter()
+                    .map(|c| c.raw_bytes().to_vec())
+                    .collect::<Vec<_>>();
+
+                self.pending_changes
+                    .entry(doc_id)
+                    .or_insert_with(Vec::new)
+                    .extend(changes);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Apply remote Automerge changes to the local document and file
+    pub async fn apply_remote_changes(
+        &mut self,
+        doc_id: &str,
+        changes: Vec<Vec<u8>>,
+    ) -> Result<()> {
+        if let Some((file_path, doc_type, _last_hash, state, owner, writers, readers)) =
+            self.db.get_document(doc_id)?
+        {
+            let mut doc = Automerge::load(&state)?;
+
+            let mut change_objs = Vec::new();
+            for raw in changes {
+                let change = Change::from_bytes(&raw)?;
+                change_objs.push(change);
+            }
+
+            doc.apply_changes(change_objs)?;
+
+            let new_state = doc.save();
+
+            let content = if doc_type == "list" {
+                if let Some((items, _)) = doc.get(automerge::ROOT, "items")? {
+                    let mut lines = Vec::new();
+                    for i in 0..doc.length(items) {
+                        if let Some((_id, val)) = doc.get(items, i)? {
+                            match val {
+                                Value::Text(t) => lines.push(t.to_string()),
+                                Value::Scalar(ScalarValue::Str(s)) => lines.push(s.to_string()),
+                                _ => {}
+                            }
+                        }
+                    }
+                    lines.join("\n")
+                } else {
+                    String::new()
+                }
+            } else if let Some((_id, value)) = doc.get(automerge::ROOT, "content")? {
+                match value {
+                    Value::Text(t) => t.to_string(),
+                    _ => String::new(),
+                }
+            } else {
+                String::new()
+            };
+
+            tokio::fs::write(&file_path, &content)
+                .await
+                .with_context(|| format!("Failed to write updated file: {}", file_path))?;
+
+            let mut hasher = Sha256::new();
+            hasher.update(content.as_bytes());
+            let new_hash = hex::encode(hasher.finalize());
+
+            self.db.upsert_document(
+                doc_id,
+                &file_path,
+                &doc_type,
+                &new_hash,
+                &new_state,
+                &owner,
+                writers.as_deref(),
+                readers.as_deref(),
+            )?;
         }
 
         Ok(())


### PR DESCRIPTION
## Summary
- mark Automerge change generation for lists as done
- add helpers for detecting document type and applying list updates
- update `handle_file_event` to store lists as item arrays
- re-render lists from Automerge on remote change

## Testing
- `cargo fmt --all` *(failed: rustfmt not installed)*
- `cargo check -p lst-syncd` *(failed to download from crates.io)*
- `cargo check -p lst-syncd --locked` *(failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_b_6846b7f01a00832199ff15500341490e