### PR TITLE
Add interactive list search to desktop app

### DIFF
--- a/apps/lst-desktop/src-tauri/src/lib.rs
+++ b/apps/lst-desktop/src-tauri/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use lst_cli::cli::commands::display_list;
-use lst_cli::storage::{list_lists, list_notes};
+use lst_cli::storage::{list_lists, list_notes, markdown::load_list};
+use lst_cli::models::List;
 use serde::{Deserialize, Serialize};
 use specta_typescript::Typescript;
 use tauri::tray::TrayIconBuilder;
@@ -19,11 +19,17 @@ fn get_notes() -> Result<Vec<String>, String> {
     list_notes().map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+#[specta::specta]
+fn get_list(name: String) -> Result<List, String> {
+    load_list(&name).map_err(|e| e.to_string())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let builder = Builder::<tauri::Wry>::new()
         // Then register them (separated by a comma)
-        .commands(collect_commands![get_lists, get_notes]);
+        .commands(collect_commands![get_lists, get_notes, get_list]);
 
     #[cfg(debug_assertions)] // <- Only export on non-release builds
     builder
@@ -51,7 +57,7 @@ pub fn run() {
 
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![get_lists, get_notes])
+        .invoke_handler(tauri::generate_handler![get_lists, get_notes, get_list])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/apps/lst-desktop/src/App.css
+++ b/apps/lst-desktop/src/App.css
@@ -145,6 +145,9 @@ html, body, #root {
   border-bottom: 1px solid var(--border-color);
   border-radius: 10px;
 }
+.list-item.selected {
+  background-color: #6c7086;
+}
 .row {
   display: flex;
   justify-content: center;

--- a/apps/lst-desktop/src/App.tsx
+++ b/apps/lst-desktop/src/App.tsx
@@ -1,57 +1,102 @@
-import { useState } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import Logo from "./assets/logo.png";
 import "./App.css";
-import { commands } from "./bindings";
-
-interface ListsOk {
-  status: "ok";
-  data: string[];
-}
-
-interface ListsErr {
-  status: "error";
-  error: string;
-}
-
-type ListResponse = ListsOk | ListsErr;
-
+import { commands, type List } from "./bindings";
 
 function App() {
-  const [lists, setLists] = useState<ListResponse | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState("");
+  const [lists, setLists] = useState<string[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [currentList, setCurrentList] = useState<List | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   async function fetchLists() {
-    try {
-      const result: ListResponse = await commands.getLists();
-      setLists(result);
-    } catch (err) {
-      // Network / IPC-level failures (rare with Tauri)
-      console.error("Failed to fetch lists:", err);
-      setLists({ status: "error", error: String(err) });
+    const res = await commands.getLists();
+    if (res.status === "ok") {
+      setLists(res.data);
+    } else {
+      setError(res.error);
     }
   }
 
+  async function loadList(name: string) {
+    const res = await commands.getList(name);
+    if (res.status === "ok") {
+      setCurrentList(res.data);
+      setShowSuggestions(false);
+      setQuery("");
+    } else {
+      setError(res.error);
+    }
+  }
 
-  function renderList(result: ListsOk) {
+  const filtered = useMemo(() => {
+    if (query === "*") return lists;
+    return lists.filter((l) => l.toLowerCase().includes(query.toLowerCase()));
+  }, [query, lists]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "/" && document.activeElement !== inputRef.current) {
+        e.preventDefault();
+        inputRef.current?.focus();
+        setShowSuggestions(true);
+      } else if (showSuggestions) {
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          setSelectedIndex((i) => (i + 1) % Math.max(filtered.length, 1));
+        } else if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setSelectedIndex((i) => (i - 1 + filtered.length) % Math.max(filtered.length, 1));
+        } else if (e.key === "Enter") {
+          e.preventDefault();
+          if (filtered[selectedIndex]) {
+            loadList(filtered[selectedIndex]);
+          }
+        }
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [showSuggestions, filtered, selectedIndex]);
+
+  function handleFocus() {
+    fetchLists();
+    setShowSuggestions(true);
+  }
+
+  function renderSuggestions() {
+    if (!showSuggestions || filtered.length === 0) return null;
     return (
       <div className="list-wrapper">
-        {result.data
-          .filter((item) =>
-            item.toLowerCase().includes(query.trim().toLowerCase())
-          )
-          .map((item) => (
-            <div key={item} className="list-item">
-              {item}
-            </div>
-          ))}
+        {filtered.map((item, idx) => (
+          <div
+            key={item}
+            className={"list-item" + (idx === selectedIndex ? " selected" : "")}
+            onMouseDown={() => loadList(item)}
+          >
+            {item}
+          </div>
+        ))}
       </div>
     );
   }
 
-  function renderError(err: ListsErr) {
-    return <p className="error">⚠️ {err.error}</p>;
+  function renderCurrentList() {
+    if (!currentList) return null;
+    return (
+      <div className="list-wrapper">
+        <h2>{currentList.title}</h2>
+        {currentList.items.map((it) => (
+          <div key={it.anchor} className="list-item">
+            {it.status === "Done" ? "[x]" : "[ ]"} {it.text}
+          </div>
+        ))}
+      </div>
+    );
   }
-
 
   return (
     <div className="background">
@@ -59,34 +104,23 @@ function App() {
         <div className="row">
           <a href="https://github.com/WismutHansen/lst" target="_blank"></a>
         </div>
-
-        <form
-          className="row"
-          onSubmit={(e) => {
-            e.preventDefault();
-            fetchLists();
-          }}
-        >
+        <form className="row" onSubmit={(e) => e.preventDefault()}>
           <div className="searchbar">
             <input
               id="query"
+              ref={inputRef}
               value={query}
               onChange={(e) => setQuery(e.currentTarget.value)}
+              onFocus={handleFocus}
               placeholder="/"
               spellCheck="false"
             />
             <img src={Logo} alt="lst icon" className="search-icon" />
-
-            <button className="button" type="button" onClick={fetchLists}>
-              L
-            </button>
           </div>
         </form>
-
-
-        {lists &&
-          (lists.status === "ok" ? renderList(lists) : renderError(lists))}
-
+        {renderSuggestions()}
+        {renderCurrentList()}
+        {error && <p className="error">⚠️ {error}</p>}
         <div className="statusbar">
           <p>hello world</p>
         </div>

--- a/apps/lst-desktop/src/bindings.ts
+++ b/apps/lst-desktop/src/bindings.ts
@@ -21,6 +21,14 @@ async getNotes() : Promise<Result<string[], string>> {
     else return { status: "error", error: e  as any };
 }
 }
+async getList(name: string) : Promise<Result<List, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_list", { name }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 }
 
 /** user-defined events **/
@@ -33,6 +41,19 @@ async getNotes() : Promise<Result<string[], string>> {
 
 /** user-defined types **/
 
+export interface ListItem {
+    text: string;
+    status: "Todo" | "Done";
+    anchor: string;
+}
+
+export interface List {
+    id: string;
+    title: string;
+    sharing: string[];
+    updated: string;
+    items: ListItem[];
+}
 
 
 /** tauri-specta globals **/


### PR DESCRIPTION
## Summary
- expose `get_list` command in Tauri backend
- support keyboard based list search in the desktop frontend
- show currently selected list and highlight list selection
- extend generated bindings with `getList` and related types

## Testing
- `cargo fmt --all` *(fails: component not installed)*
- `cargo clippy -- -D warnings` *(fails: component not installed)*
- `cargo test --workspace --quiet` *(fails: glib-2.0 library missing)*

------
https://chatgpt.com/codex/tasks/task_b_685487df798c8321a04fad6bdf5eb710