### PR TITLE
Add note tidier and ensure tests run

### DIFF
--- a/crates/lst-cli/src/cli/mod.rs
+++ b/crates/lst-cli/src/cli/mod.rs
@@ -176,6 +176,10 @@ pub enum NoteCommands {
     /// List all notes
     #[clap(name = "ls")]
     ListNotes {},
+
+    /// Tidy all notes: ensure proper YAML frontmatter
+    #[clap(name = "tidy")]
+    Tidy,
 }
 
 #[derive(Subcommand)]

--- a/crates/lst-cli/src/main.rs
+++ b/crates/lst-cli/src/main.rs
@@ -54,6 +54,9 @@ async fn main() -> Result<()> {
             NoteCommands::ListNotes {} => {
                 cli::commands::list_notes(cli.json)?;
             }
+            NoteCommands::Tidy => {
+                cli::commands::tidy_notes(cli.json)?;
+            }
         },
         // Commands::Post(post_cmd) => {
         //     match post_cmd {
@@ -102,7 +105,11 @@ async fn main() -> Result<()> {
                 eprintln!("Image commands not implemented yet");
             }
         },
-        Commands::Share { document, writers, readers } => {
+        Commands::Share {
+            document,
+            writers,
+            readers,
+        } => {
             cli::commands::share_document(document, writers.as_deref(), readers.as_deref())?;
         }
         Commands::Unshare { document } => {

--- a/crates/lst-cli/src/models/list.rs
+++ b/crates/lst-cli/src/models/list.rs
@@ -1,11 +1,10 @@
 use crate::storage::get_lists_dir;
-use anyhow::Result;
 use chrono::{DateTime, Utc};
 use rand::distributions::{Alphanumeric, DistString};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use specta::Type;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use uuid::Uuid;
 
 pub fn generate_anchor() -> String {


### PR DESCRIPTION
## Summary
- implement `tidy` subcommand for notes
- resolve unused variable warnings
- clean up unused imports
- install system libs for glib, GTK and WebKit and run tests

## Testing
- `cargo test --workspace --quiet`

------
https://chatgpt.com/codex/tasks/task_b_6863ffd53158832186880f40e8c6ceaa