### PR TITLE
Fix auth token handling in sync daemon and server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +612,15 @@ name = "bitstream-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -3281,12 +3302,14 @@ name = "lst-cli"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "argon2",
  "chrono",
  "clap",
  "colored",
  "console",
  "dialoguer",
  "dirs 5.0.1",
+ "hex",
  "lazy_static",
  "rand 0.8.5",
  "regex",
@@ -3295,6 +3318,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "specta",
  "specta-typescript",
  "tauri-specta",
@@ -3369,6 +3393,7 @@ name = "lst-server"
 version = "0.1.3"
 dependencies = [
  "anyhow",
+ "argon2",
  "axum",
  "base64 0.22.1",
  "chrono",
@@ -3385,6 +3410,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "thiserror 1.0.69",
  "tokio",
@@ -4189,6 +4215,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ notify = "6.1.1"
 automerge = { version = "0.6" }
 rusqlite = { version = "0.32.1", features = ["bundled"] }
 sha2 = "0.10"
+hex = "0.4"
+argon2 = "0.5"
 chacha20poly1305 = { version = "0.10", features = ["std"] }
 tokio-tungstenite = "0.21"
 futures-util = "0.3"

--- a/crates/lst-cli/Cargo.toml
+++ b/crates/lst-cli/Cargo.toml
@@ -55,6 +55,9 @@ tauri-specta = { version = "=2.0.0-rc.21", features = ["derive", "typescript"] }
 reqwest = { workspace = true, features = ["json"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 url = "2.5.0"
+sha2 = "0.10"
+hex = "0.4"
+argon2 = { workspace = true }
 
 [features]
 default = ["lists"]

--- a/crates/lst-server/Cargo.toml
+++ b/crates/lst-server/Cargo.toml
@@ -41,6 +41,8 @@ image = { workspace = true }
 rand = { workspace = true }
 lettre = { workspace = true }
 dirs = { workspace = true }
+sha2 = { workspace = true }
+argon2 = { workspace = true }
 
 # Internal dependencies
 lst-proto = { path = "../lst-proto", version = "0.1.3" }
@@ -53,3 +55,4 @@ sqlx = { version = "0.8.6", features = [
 
 [dev-dependencies]
 reqwest = { workspace = true }
+argon2 = { workspace = true }

--- a/crates/lst-server/tests/integration_tests.rs
+++ b/crates/lst-server/tests/integration_tests.rs
@@ -1,15 +1,13 @@
 use serde_json::json;
+use argon2::{password_hash::SaltString, Argon2, Algorithm, Params, PasswordHasher, Version};
 use std::time::Duration;
 use tokio::time::sleep;
 
 #[tokio::test]
 async fn test_health_endpoint() {
     let client = reqwest::Client::new();
-    let response = client
-        .get("http://127.0.0.1:3001/api/health")
-        .send()
-        .await;
-    
+    let response = client.get("http://127.0.0.1:3001/api/health").send().await;
+
     match response {
         Ok(resp) => {
             assert_eq!(resp.status(), 200);
@@ -26,32 +24,32 @@ async fn test_health_endpoint() {
 #[tokio::test]
 async fn test_auth_request_endpoint() {
     let client = reqwest::Client::new();
-    
+
+    let params = Params::new(128 * 1024, 3, 2, None).unwrap();
+    let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+    let salt = SaltString::encode_b64(b"clientstatic").unwrap();
+    let hash = argon2.hash_password(b"hunter42", &salt).unwrap().to_string();
+
     let payload = json!({
         "email": "test@example.com",
-        "host": "127.0.0.1:3001"
+        "host": "127.0.0.1:3001",
+        "password_hash": hash
     });
-    
+
     let response = client
         .post("http://127.0.0.1:3001/api/auth/request")
         .json(&payload)
         .send()
         .await;
-    
+
     match response {
         Ok(resp) => {
             if resp.status().is_success() {
                 let json: serde_json::Value = resp.json().await.unwrap();
-                assert!(json.get("token").is_some());
-                assert!(json.get("qr_png_base64").is_some());
-                assert!(json.get("login_url").is_some());
-                
-                // Verify the login URL format
-                let login_url = json["login_url"].as_str().unwrap();
-                assert!(login_url.starts_with("lst-login://"));
-                assert!(login_url.contains("auth/verify"));
-                
-                println!("Auth request successful - token: {}", json["token"]);
+                assert_eq!(
+                    json.get("status"),
+                    Some(&serde_json::Value::String("ok".into()))
+                );
             } else {
                 println!("Auth request failed with status: {}", resp.status());
             }
@@ -65,46 +63,32 @@ async fn test_auth_request_endpoint() {
 #[tokio::test]
 async fn test_full_auth_flow() {
     let client = reqwest::Client::new();
-    
+
     // Step 1: Request auth token
+    let params = Params::new(128 * 1024, 3, 2, None).unwrap();
+    let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+    let salt = SaltString::encode_b64(b"clientstatic").unwrap();
+    let hash = argon2.hash_password(b"hunter42", &salt).unwrap().to_string();
+
     let payload = json!({
-        "email": "test@example.com", 
-        "host": "127.0.0.1:3001"
+        "email": "test@example.com",
+        "host": "127.0.0.1:3001",
+        "password_hash": hash
     });
-    
+
     let auth_response = client
         .post("http://127.0.0.1:3001/api/auth/request")
         .json(&payload)
         .send()
         .await;
-    
+
     match auth_response {
         Ok(resp) if resp.status().is_success() => {
             let auth_json: serde_json::Value = resp.json().await.unwrap();
-            let token = auth_json["token"].as_str().unwrap();
-            
-            // Step 2: Verify the token (should work immediately)
-            let verify_payload = json!({
-                "email": "test@example.com",
-                "token": token
-            });
-            
-            let verify_response = client
-                .post("http://127.0.0.1:3001/api/auth/verify")
-                .json(&verify_payload)
-                .send()
-                .await
-                .unwrap();
-            
-            if verify_response.status().is_success() {
-                let verify_json: serde_json::Value = verify_response.json().await.unwrap();
-                assert!(verify_json.get("jwt").is_some());
-                assert_eq!(verify_json["user"], "test@example.com");
-                
-                println!("Full auth flow successful - JWT received");
-            } else {
-                println!("Token verification failed with status: {}", verify_response.status());
-            }
+            assert_eq!(
+                auth_json.get("status"),
+                Some(&serde_json::Value::String("ok".into()))
+            );
         }
         _ => {
             println!("Server not running - start with: cargo run --bin lst-server -- --config test-server.toml");
@@ -112,21 +96,21 @@ async fn test_full_auth_flow() {
     }
 }
 
-#[tokio::test] 
+#[tokio::test]
 async fn test_invalid_token_rejection() {
     let client = reqwest::Client::new();
-    
+
     let verify_payload = json!({
         "email": "test@example.com",
         "token": "INVALID-TOKEN-123"
     });
-    
+
     let response = client
         .post("http://127.0.0.1:3001/api/auth/verify")
         .json(&verify_payload)
         .send()
         .await;
-    
+
     match response {
         Ok(resp) => {
             assert_eq!(resp.status(), 401); // Unauthorized

--- a/crates/lst-syncd/src/sync.rs
+++ b/crates/lst-syncd/src/sync.rs
@@ -333,10 +333,11 @@ impl SyncManager {
             Some(u) => u,
             None => return Ok(()),
         };
-        let token = syncd
-            .auth_token
-            .as_ref()
-            .context("auth_token not configured")?;
+        let token = self
+            .config
+            .get_jwt()
+            .context("No valid JWT token. Run 'lst auth request <email>' to authenticate")?
+            .to_string();
 
         let device_id = syncd
             .device_id
@@ -346,9 +347,7 @@ impl SyncManager {
         let (ws, _) = connect_async(url).await?;
         let (mut write, mut read) = ws.split();
 
-        let auth_msg = lst_proto::ClientMessage::Authenticate {
-            jwt: token.clone(),
-        };
+        let auth_msg = lst_proto::ClientMessage::Authenticate { jwt: token.clone() };
         write
             .send(Message::Text(serde_json::to_string(&auth_msg)?))
             .await?;


### PR DESCRIPTION
## Summary
- require hashed password when requesting auth token
- server stores salted password hash and validates on subsequent requests
- print auth token locally or email it, never send via API
- switch to Argon2id hashing with strong parameters

## Testing
- `cargo check -p lst-server -p lst-syncd` *(fails: missing libsoup-3.0 and javascriptcoregtk-4.1 libs)*

------
https://chatgpt.com/codex/tasks/task_b_6865622451288321a908670257003292